### PR TITLE
Add version sync script and update docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Repository Guidelines
+
+- Always ensure that `package.json` and `public/manifest.json` share the same `version` field.
+- Use `npm version <patch|minor|major>` to bump versions. This triggers the `version` script which updates the manifest.
+- Run `npm test` before committing changes.

--- a/README.md
+++ b/README.md
@@ -34,3 +34,8 @@ npm run build
 
 The compiled extension will be in the `dist/` directory.
 
+## Incrementing the Version
+
+Run `npm version <patch|minor|major>` to bump the project version. The `version` script will automatically update `public/manifest.json` so its version matches `package.json`.
+
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "only-video",
-  "version": "1.0.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "only-video",
-      "version": "1.0.0",
+      "version": "0.1.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/preset-env": "^7.27.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "only-video",
-  "version": "1.0.0",
+  "version": "0.1.1",
   "description": "Chrome extension to show only video elements",
   "main": "background.js",
   "type": "module",
@@ -8,7 +8,9 @@
     "dev": "vite",
     "build": "vite build",
     "test": "jest",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "sync-version": "node ./scripts/sync-version.js",
+    "version": "node ./scripts/sync-version.js"
   },
   "keywords": [],
   "author": "",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,10 +2,13 @@
   "name": "__MSG_name__",
   "short_name": "__MSG_name__",
   "description": "__MSG_description__",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "default_locale": "en",
   "author": "Mark Holmes",
-  "permissions": ["activeTab", "scripting"],
+  "permissions": [
+    "activeTab",
+    "scripting"
+  ],
   "background": {
     "service_worker": "background.js"
   },
@@ -25,8 +28,12 @@
   },
   "web_accessible_resources": [
     {
-      "resources": ["only-video.css"],
-      "matches": ["<all_urls>"]
+      "resources": [
+        "only-video.css"
+      ],
+      "matches": [
+        "<all_urls>"
+      ]
     }
   ],
   "manifest_version": 3

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -1,0 +1,13 @@
+import { readFileSync, writeFileSync } from 'fs';
+
+const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
+const manifestPath = 'public/manifest.json';
+const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+
+if (manifest.version !== pkg.version) {
+  manifest.version = pkg.version;
+  writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n');
+  console.log(`Updated manifest version to ${pkg.version}`);
+} else {
+  console.log('manifest version already matches package.json');
+}


### PR DESCRIPTION
## Summary
- add AGENTS instructions
- add `scripts/sync-version.js` and hook into npm `version`
- sync manifest version with package.json
- document version bumping in README
- set initial version to 0.1.1

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683fb34c29388332928848bf826b376b