### PR TITLE
Migrate project to TypeScript

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["@babel/preset-env"]
+  "presets": ["@babel/preset-env", "@babel/preset-typescript"]
 }

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ This project uses the latest Node.js LTS release (v22). The repository includes
 an `.nvmrc` file, so running `nvm use` will automatically select the correct
 version.
 
+The extension source code is written in **TypeScript**, which is compiled during
+the build process.
+
 ## Installing from Releases
 
 Automated GitHub releases include a prebuilt copy of the extension and an auto-generated changelog describing the changes.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 export default {
   transform: {
-    '^.+\\.js$': 'babel-jest'
+    '^.+\\.[tj]s$': 'babel-jest'
   },
   testEnvironment: 'jsdom'
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,14 @@
       "license": "MIT",
       "devDependencies": {
         "@babel/preset-env": "^7.27.2",
+        "@babel/preset-typescript": "^7.27.1",
+        "@types/chrome": "^0.0.326",
+        "@types/jest": "^29.5.14",
         "babel-jest": "^30.0.0-beta.3",
         "eslint": "^8.57.1",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^30.0.0-beta.3",
+        "typescript": "^5.8.3",
         "vite": "^6.3.5"
       },
       "engines": {
@@ -1548,6 +1552,26 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-typescript": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.27.1.tgz",
+      "integrity": "sha512-Q5sT5+O4QUebHdbwKedFBEwRLb02zJ7r4A5Gg2hUoLuU3FjdMcyqcywqUrLCaDsFCxzokf7u9kuy7qz51YUuAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.1",
+        "@babel/helper-create-class-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/plugin-syntax-typescript": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-unicode-escapes": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.27.1.tgz",
@@ -1712,6 +1736,26 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/@babel/preset-typescript": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.27.1.tgz",
+      "integrity": "sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+        "@babel/plugin-transform-typescript": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/template": {
@@ -4024,10 +4068,38 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/chrome": {
+      "version": "0.0.326",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.326.tgz",
+      "integrity": "sha512-WS7jKf3ZRZFHOX7dATCZwqNJgdfiSF0qBRFxaO0LhIOvTNBrfkab26bsZwp6EBpYtqp8loMHJTnD6vDTLWPKYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/filesystem": "*",
+        "@types/har-format": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
       "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/filesystem": {
+      "version": "0.0.36",
+      "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.36.tgz",
+      "integrity": "sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/filewriter": "*"
+      }
+    },
+    "node_modules/@types/filewriter": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.33.tgz",
+      "integrity": "sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==",
       "dev": true,
       "license": "MIT"
     },
@@ -4040,6 +4112,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/har-format": {
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.16.tgz",
+      "integrity": "sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -4066,6 +4145,17 @@
       "license": "MIT",
       "dependencies": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "29.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
+      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
       }
     },
     "node_modules/@types/jsdom": {
@@ -9522,6 +9612,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -17,10 +17,14 @@
   "license": "MIT",
   "devDependencies": {
     "@babel/preset-env": "^7.27.2",
+    "@babel/preset-typescript": "^7.27.1",
+    "@types/chrome": "^0.0.326",
+    "@types/jest": "^29.5.14",
     "babel-jest": "^30.0.0-beta.3",
     "eslint": "^8.57.1",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^30.0.0-beta.3",
+    "typescript": "^5.8.3",
     "vite": "^6.3.5"
   },
   "engines": {

--- a/src/background.test.ts
+++ b/src/background.test.ts
@@ -8,7 +8,7 @@ global.chrome = {
 };
 
 beforeAll(async () => {
-  await import('./background.js');
+  await import('./background');
 });
 
 describe('background onClicked', () => {
@@ -34,7 +34,7 @@ describe('foreground multiple videos', () => {
 
   test('handles multiple videos', async () => {
     document.body.innerHTML = '<video id="v1"></video><video id="v2"></video>';
-    await import('./foreground.js');
+    await import('./foreground');
     const gallery = document.querySelector('.only-video-gallery');
     expect(gallery).not.toBeNull();
     expect(gallery.querySelectorAll('video').length).toBe(2);
@@ -42,7 +42,7 @@ describe('foreground multiple videos', () => {
 
   test('focuses on single video when clicked', async () => {
     document.body.innerHTML = '<video id="v1"></video><video id="v2"></video>';
-    await import('./foreground.js');
+    await import('./foreground');
     const video = document.getElementById('v1');
     video.click();
     const single = document.querySelector('.only-video-single-container');

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,8 +1,12 @@
-const onlyVideoLog = s => console.log(`[only video] ${s}`);
+const onlyVideoLog = (s: string): void => console.log(`[only video] ${s}`);
 
-chrome.action.onClicked.addListener(async tab => {
+chrome.action.onClicked.addListener(async (tab: chrome.tabs.Tab) => {
     onlyVideoLog('clicked a tab');
     const currentTabId = tab.id;
+    if (currentTabId === undefined) {
+        onlyVideoLog('no tab id');
+        return;
+    }
     try {
         await chrome.scripting.executeScript({
             target: { tabId: currentTabId },
@@ -15,6 +19,7 @@ chrome.action.onClicked.addListener(async tab => {
         });
         onlyVideoLog('inserted css');
     } catch (e) {
-        onlyVideoLog(`error: ${e}`);
+        const message = e instanceof Error ? e.message : String(e);
+        onlyVideoLog(`error: ${message}`);
     }
 });

--- a/src/foreground.test.ts
+++ b/src/foreground.test.ts
@@ -13,14 +13,14 @@ describe('foreground script', () => {
 
   test('handles single video', async () => {
     document.body.innerHTML = '<video></video>';
-    await import('./foreground.js');
+    await import('./foreground');
     const container = document.querySelector('.only-video-single-container');
     expect(container).not.toBeNull();
     expect(container.querySelector('video')).not.toBeNull();
   });
 
   test('handles no videos', async () => {
-    await import('./foreground.js');
+    await import('./foreground');
     const notice = document.querySelector('.only-video-no-videos');
     expect(notice).not.toBeNull();
     jest.runAllTimers();

--- a/src/foreground.ts
+++ b/src/foreground.ts
@@ -1,10 +1,10 @@
-import { randomDirection, randomAlphaNumStr } from './utils.js';
+import { randomDirection, randomAlphaNumStr } from './utils';
 
 (() => {
-    const head = document.querySelector('head');
-    const onlyVideoLog = s => console.log(`[only video] ${s}`);
+    const head = document.querySelector<HTMLHeadElement>('head');
+    const onlyVideoLog = (s: string): void => console.log(`[only video] ${s}`);
 
-    const createVideoSwoopAnimation = video => {
+    const createVideoSwoopAnimation = (video: HTMLVideoElement): void => {
         const animationName = randomAlphaNumStr();
         const randomHeight = randomDirection() * (Math.ceil(Math.random() * 100) + 100);
         const randomWidth = randomDirection() * (Math.ceil(Math.random() * 100) + 100);
@@ -26,31 +26,31 @@ import { randomDirection, randomAlphaNumStr } from './utils.js';
         const style = document.createElement('style');
         style.type = 'text/css';
         style.appendChild(document.createTextNode(css));
-        head.appendChild(style);
+        head?.appendChild(style);
 
-        video.style['animation-name'] = animationName;
+        video.style.animationName = animationName;
     };
 
-    const setVideoStyling = video => {
+    const setVideoStyling = (video: HTMLVideoElement): void => {
         video.removeAttribute('height');
         video.removeAttribute('width');
         video.removeAttribute('style');
 
-        video.setAttribute('class', 'only-video-video');
-        video.setAttribute('controls', true);
+        video.className = 'only-video-video';
+        video.controls = true;
     };
 
-    const setGalleryVideoStyling = video => {
+    const setGalleryVideoStyling = (video: HTMLVideoElement): void => {
         video.removeAttribute('height');
         video.removeAttribute('width');
         video.removeAttribute('style');
 
         createVideoSwoopAnimation(video);
-        video.setAttribute('class', 'only-video-video only-video-gallery-video');
-        video.setAttribute('controls', true);
+        video.className = 'only-video-video only-video-gallery-video';
+        video.controls = true;
     };
 
-    const onlyVideo = theChosenOne => {
+    const onlyVideo = (theChosenOne: HTMLVideoElement): void => {
         setVideoStyling(theChosenOne);
         const container = document.createElement('div');
         container.setAttribute('class', 'only-video-single-container');
@@ -59,7 +59,7 @@ import { randomDirection, randomAlphaNumStr } from './utils.js';
         body.appendChild(container);
     };
 
-    const aSetOfVideos = videos => {
+    const aSetOfVideos = (videos: NodeListOf<HTMLVideoElement>): void => {
         const container = document.createElement('div');
         container.setAttribute('class', 'only-video-container');
 
@@ -71,7 +71,7 @@ import { randomDirection, randomAlphaNumStr } from './utils.js';
             setGalleryVideoStyling(video);
             video.muted = true;
             video.addEventListener('click', e => {
-                onlyVideo(e.target);
+                onlyVideo(e.currentTarget as HTMLVideoElement);
             });
             gallery.appendChild(video);
         });
@@ -80,8 +80,8 @@ import { randomDirection, randomAlphaNumStr } from './utils.js';
     };
 
     onlyVideoLog('attempting to make the page video only');
-    const body = document.querySelector('body');
-    const videos = document.querySelectorAll('video');
+    const body = document.querySelector<HTMLBodyElement>('body')!;
+    const videos = document.querySelectorAll<HTMLVideoElement>('video');
     if (videos && videos.length) {
         // Use classList to avoid a leading "null" when the body has no class
         body.classList.add('only-video-body');

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,0 @@
-export const randomDirection = () => Math.random() > 0.5 ? 1 : -1;
-export const randomAlphaNumStr = () =>
-  btoa(Math.random() * 1000000).replace(/[^a-zA-Z0-9]/g, '');

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,4 +1,4 @@
-import { randomDirection, randomAlphaNumStr } from './utils.js';
+import { randomDirection, randomAlphaNumStr } from './utils';
 
 describe('utils', () => {
   test('randomDirection returns either 1 or -1', () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,5 @@
+export const randomDirection = (): 1 | -1 =>
+  Math.random() > 0.5 ? 1 : -1;
+
+export const randomAlphaNumStr = (): string =>
+  btoa(String(Math.random() * 1000000)).replace(/[^a-zA-Z0-9]/g, '');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "allowJs": false,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,8 +5,8 @@ export default defineConfig({
   build: {
     rollupOptions: {
       input: {
-        background: 'src/background.js',
-        foreground: 'src/foreground.js',
+        background: 'src/background.ts',
+        foreground: 'src/foreground.ts',
         style: 'src/only-video.css'
       },
       output: {


### PR DESCRIPTION
## Summary
- convert source and tests to TypeScript
- configure Babel and Jest for TypeScript
- update Vite inputs
- document TypeScript usage
- strengthen typing throughout the extension

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683fc8c76bd483329d1a28a3e7343051